### PR TITLE
creating i386_pc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,16 +5,16 @@ export AS  = nasm
 export AR = $(PREFIX)ar
 export LD  = $(PREFIX)ld
 export CXX = $(PREFIX)g++
-export LDFLAGS  = -nostdlib
+export LDFLAGS  = -nostdlib -flto --strip-all
 export CPPFLAGS =  -nostdinc++ -I$(SRC_DIR)
 export CFLAGS   = -c -ffreestanding -mtune=generic -march=i386 -Wall -Wextra
-export CXXFLAGS = $(CFLAGS) -fno-rtti   
+export CXXFLAGS = $(CFLAGS) -fno-rtti -fno-exceptions
 
 export TARGET = i386
 
 MAJOR_VERSION = 0
 MINOR_VERSION = 1
-FIX_VERSION   = 1
+FIX_VERSION   = 2 # 2 implementing the apics functionnality of the 0.1* version
 
 DIR = arch beetle boot
 DEBUG = 

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ export CFLAGS   = -c -ffreestanding -mtune=generic -march=i386 -Wall -Wextra
 export CXXFLAGS = $(CFLAGS) -fno-rtti -fno-exceptions
 
 export TARGET = i386
+export PLATFORM = pc
 
 MAJOR_VERSION = 0
 MINOR_VERSION = 1

--- a/arch/i386/apic.hpp
+++ b/arch/i386/apic.hpp
@@ -107,4 +107,21 @@ namespace ARCH::I386::APIC::LVT
 	}
 }
 
+namespace ARCH::I386::APIC
+{
+	inline uint32_t get_apic_entry (const unsigned int n)
+	{
+		uint32_t* apic = (uint32_t*)0xFEE00000;
+		return apic[n * 4];
+	} 
+
+	inline void write_apic_entry (const unsigned int n, const uint32_t v)
+	{
+		uint32_t* apic = (uint32_t*)(0xFEE00000);
+		apic[n * 4] = v;
+	}
+
+	inline uint32_t get_apic_version (void) { return get_apic_entry(3); }
+}
+
 #endif

--- a/arch/i386/get_cpuid.s
+++ b/arch/i386/get_cpuid.s
@@ -3,12 +3,10 @@ global get_cpuid
 ;ecx : cpuid function to call
 ;edx : addres of the CPUIDResult structur to fill
 get_cpuid:
-	xchg bx, bx
 	mov eax, ecx
-	mov edi, edx
 	cpuid
-	mov dword [edi + 4 * 0], eax
-	mov dword [edi + 4 * 1], ebx
-	mov dword [edi + 4 * 2], ecx
-	mov dword [edi + 4 * 3], edx
+	mov dword [edx + 4 * 0], eax
+	mov dword [edx + 4 * 1], ebx
+	mov dword [edx + 4 * 2], ecx
+	mov dword [edx + 4 * 3], edx
 	ret

--- a/arch/i386/switch_idt.s
+++ b/arch/i386/switch_idt.s
@@ -5,12 +5,6 @@ SECTION .text
 ; and then switches the current idt to the one described by this idtr
 ; this function will be called once at the start of the system
 switch_idt:
-    ;Disabling the two PICs, we want to use APIC instead
-    ;This thing should really go in a PC part of the initialization
-    ;Because it has nothing to do with x86 stuff
-    mov al, 0xFF
-    out 0xA1, al
-    out 0x21, al
     lidt [ecx]
     sti
     ret

--- a/beetle/Makefile
+++ b/beetle/Makefile
@@ -1,10 +1,9 @@
-PRODUCT = libsys.a
-TARGET_OBJ = $(SRC_DIR)/arch/$(TARGET)/$(TARGET).o
-CXXSRC = system/system_$(TARGET).cpp
+FINAL_OBJ = $(SRC_DIR)/arch/$(TARGET)/$(TARGET).o
+CXXSRC = system/system_$(TARGET)_$(PLATFORM).cpp
 CXXOBJ = $(CXXSRC:.cpp=.o)
 PRODUCT=libsystem.a
 
-$(PRODUCT): $(CXXOBJ) $(TARGET_OBJ)
+$(PRODUCT): $(CXXOBJ) $(FINAL_OBJ)
 	$(AR) rcs $@ $^
 
 %.o: %.cpp include/system.hpp

--- a/beetle/system/system_i386.cpp
+++ b/beetle/system/system_i386.cpp
@@ -55,7 +55,7 @@ void BEETLE::SYSTEM::init()
 	/* Initialize the new GDT */
     init_gdt(gdt);
 
-	/* Initialize the new GDT */
+	/* Initialize the new IDT */
 	init_idt(idt);
 
     /* Initializing the local APIC if present */

--- a/beetle/system/system_i386_pc.cpp
+++ b/beetle/system/system_i386_pc.cpp
@@ -79,6 +79,12 @@ void init_gdt (ARCH::I386::GDT& gdt)
 
 void init_idt (ARCH::I386::IDT& idt)
 {
+    //Shuting down the pic
+    __asm__ ("movb $0xFF, %al\n"
+    "outb %al, $0xA1\n"
+    "outb %al, $0x21\n");
+
+    //Initializing IDT descriptors
     idt.add(ARCH::I386::create_interruptgate_descriptor((uint32_t)interrupt_DE,  0x8, PRESENT | PRIVILEGE0));
     idt.add(ARCH::I386::create_interruptgate_descriptor((uint32_t)interrupt_DB,  0x8, PRESENT | PRIVILEGE0));
     idt.add(ARCH::I386::create_interruptgate_descriptor((uint32_t)interrupt_NMI, 0x8, PRESENT | PRIVILEGE0));


### PR DESCRIPTION
When we setup interrupts we have to disable the PIC, but the pic is part of the PC architecture not of the IA_32. So we move the code to disable the PIC in the initialisation code for i386_pc. Before, the PIC was disabled when switching the IDT (in the file init_idt.s)